### PR TITLE
Fix quota upload

### DIFF
--- a/lib/vsc/filesystem/quota/ptools.py
+++ b/lib/vsc/filesystem/quota/ptools.py
@@ -263,7 +263,6 @@ class UsageReporter(CLI):
 
     def process_user_quota(self, storage_name, quota_list, client):
         institute = self.options.host_institute
-        path_template = self.storage.path_templates[institute][storage_name]
 
         logging.info("Logging user quota to account page")
         logging.debug("Considering the following quota items for pushing: %s", quota_list)

--- a/lib/vsc/filesystem/quota/ptools.py
+++ b/lib/vsc/filesystem/quota/ptools.py
@@ -126,7 +126,7 @@ class UsageReporter(CLI):
             else:
                 if not dry_run:
                     self.cache.set(cache_key, event, expire=864000)
-                logging.debug("Event %s differs from %s, adding to usage list", event, cached_usage)
+                logging.debug("Event %s differs from %s, considering adding to usage list", event, cached_usage)
 
                 # user and fileset may be a number and need translation, but only for the events we will
                 # actually upload
@@ -134,6 +134,7 @@ class UsageReporter(CLI):
                 event = event._replace(entity=entity, fileset=fileset)
 
                 if entity is not None and fileset is not None:
+                    logging.debug("Adding event %s to usage list", event)
                     self.usage_list.append(event)
 
     def consolidate(self, entries):
@@ -252,7 +253,7 @@ class UsageReporter(CLI):
                 if self.system_storage_map[storage_name] == q.filesystem and q.kind == "FILESET"
             ]
             logging.debug("Fileset quota for storage %s: %s", storage_name, fileset_quota_data)
-            #self.process_fileset_quota(storage_name, fileset_quota_data, ap_client)
+            self.process_fileset_quota(storage_name, fileset_quota_data, ap_client)
 
             usr_quota_data = [
                 q for q in self.usage_list if self.system_storage_map[storage_name] == q.filesystem and q.kind == "USR"
@@ -269,19 +270,17 @@ class UsageReporter(CLI):
 
         with DjangoPusher(storage_name, client, QUOTA_USER_KIND, self.options.dry_run) as pusher:
             for quota in quota_list:
-                # no longer a known user, we got the numerical UID, so no need to push info
-                continue
-
-                logging.info("Pushing data %s", quota)
 
                 user_name = quota.entity
                 fileset_name = path_template["user"](user_name)[1]
                 fileset_re = (
-                    rf"^(vsc[1-4]|{VO_PREFIX_BY_SITE[institute]}|"
-                    rf"{VO_SHARED_PREFIX_BY_SITE[institute]}|{fileset_name})"
+                    rf"^(vsc[1-5]|{VO_PREFIX_BY_SITE[institute]}|"
+                    rf"{VO_SHARED_PREFIX_BY_SITE[institute]})"
                 )
+                entity_re = rf"^vsc[1-5]"
 
-                if re.search(fileset_re, quota.fileset):
+                if re.search(fileset_re, quota.fileset) and re.search(entity_re, quota.entity):
+                    logging.debug("Pushing data %s", quota)
                     pusher.push_quota(user_name, quota)
 
     def process_fileset_quota(self, storage_name, quota_list, client):
@@ -293,7 +292,6 @@ class UsageReporter(CLI):
         with DjangoPusher(storage_name, client, QUOTA_VO_KIND, self.options.dry_run) as pusher:
             for quota in quota_list:
                 fileset_name = quota.fileset
-                logging.debug("Fileset %s quota: %s", fileset_name, quota)
 
                 if not fileset_name.startswith(VO_PREFIX_BY_SITE[institute]):
                     continue
@@ -304,6 +302,7 @@ class UsageReporter(CLI):
                     vo_name = fileset_name
                     shared = False
 
+                logging.debug("Pushing data %s", quota)
                 pusher.push_quota(vo_name, quota, shared=shared)
 
     def _update_usage(self, usage):

--- a/lib/vsc/filesystem/quota/ptools.py
+++ b/lib/vsc/filesystem/quota/ptools.py
@@ -272,7 +272,6 @@ class UsageReporter(CLI):
             for quota in quota_list:
 
                 user_name = quota.entity
-                fileset_name = path_template["user"](user_name)[1]
                 fileset_re = (
                     rf"^(vsc[1-5]|{VO_PREFIX_BY_SITE[institute]}|"
                     rf"{VO_SHARED_PREFIX_BY_SITE[institute]})"

--- a/lib/vsc/filesystem/quota/ptools.py
+++ b/lib/vsc/filesystem/quota/ptools.py
@@ -275,7 +275,7 @@ class UsageReporter(CLI):
                     rf"^(vsc[1-5]|{VO_PREFIX_BY_SITE[institute]}|"
                     rf"{VO_SHARED_PREFIX_BY_SITE[institute]})"
                 )
-                entity_re = rf"^vsc[1-5]"
+                entity_re = r"^vsc[1-5]"
 
                 if re.search(fileset_re, quota.fileset) and re.search(entity_re, quota.entity):
                     logging.debug("Pushing data %s", quota)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ vsc-filesystems-quota base distribution setup.py
 @author: Kenneth Waegeman (Ghent University)
 @author: Andy Georges (Ghent University)
 """
-import vsc.install.shared_setup as shared_setup
+from vsc.install import shared_setup
 from vsc.install.shared_setup import ag
 
 PACKAGE = {

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ PACKAGE = {
         'vsc-filesystems >= 2.0.0',
         'vsc-kafka',
         'prometheus_client',
+        'requests <= 2.25',
     ],
     'extras_require': {
         'oceanstor': ['vsc-filesystem-oceanstor >= 0.6.0'],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag
 
 PACKAGE = {
-    'version': '2.3.0',
+    'version': '2.3.1',
     'author': [ag],
     'maintainer': [ag],
     'excluded_pkgs_rpm': ['vsc', 'vsc.filesystem', 'vsc.filesystem.quota'],


### PR DESCRIPTION
Since we now pull from the raw data that is not filtered by gpfsbeat, we need to do some filtering before pushing to the AP

- filesets need to start with vsc1-5, gvo, gvos (yes, the latter sounds redundant, but we may have other shared data filesets at some point)
- entities need to be actual VSC users for USR data